### PR TITLE
i18n: Add East-Asian fonts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: kano-fonts
 Architecture: all
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, fonts-arphic-ukai, fonts-arphic-uming,
+ fonts-ipafont-mincho, fonts-ipafont-gothic, fonts-unfonts-core,
 Replaces: kano-desktop (<< 1.0-60.20140423)
 Breaks: kano-desktop (<< 1.0-60.20140423)
 Description: Font families used in Kanux


### PR DESCRIPTION
To permit translating into East-Asian languages, install the fonts
required to display them. These additions allow:
- Chinese
- Japanese
- Korean

Source: en.wikipedia.org/wiki/Help:Multilingual_support_(East_Asian)

cc @pazdera @convolu 
